### PR TITLE
Exposing FrozenModel as top level import

### DIFF
--- a/layer_freeze/__init__.py
+++ b/layer_freeze/__init__.py
@@ -1,1 +1,6 @@
+from .model_agnostic_freezing import FrozenModel
 
+
+__all__ = [
+    "FrozenModel"
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,16 +9,17 @@ description = "A tool for hyperparameter optimization using successive halving"
 authors = [{ name = "Timur Michael Carstensen", email = "timurcarstensen@gmail.com" }]
 license = { file = "LICENSE" }
 readme = "README.md"
-requires-python = ">=3.11"
+requires-python = ">=3.10"
 classifiers = [
     "Programming Language :: Python :: 3",
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
 ]
 dependencies = [
+    "rich",
     "torch>=2.0.0",
     "torchvision>=0.15.0",
-    "neural-pipeline-search@git+https://github.com/automl/neps.git",
+    # "neural-pipeline-search@git+https://github.com/automl/neps.git",
     "mup",
     "GitPython",
 ]


### PR DESCRIPTION
Edited `__init__.py` such that the following now works:
```python
from layer_freeze import FrozenModel
```

Also, removed NePS as a dependency to keep this repo light and use NePS as a *wrapper* over this in the experiment repos.
